### PR TITLE
Add color ordering for usa canada

### DIFF
--- a/ingest/defaults/geolocation_rules.tsv
+++ b/ingest/defaults/geolocation_rules.tsv
@@ -4,3 +4,8 @@
 # If creating a general rule, then the raw field value can be substituted with '*'
 # Lines starting with '#' will be ignored as comments.
 # Trailing '#' will be ignored as comments.
+North America/USA/NorthCarolina/*	North America/USA/North Carolina/*
+North America/Canada/BritishColumbia/*	North America/Canada/British Columbia/*
+North America/Canada/NewBrunswick/*	North America/Canada/New Brunswick/*
+North America/Canada/NovaScotia/*	North America/Canada/Nova Scotia/*
+North America/Canada/Newfoundland/*	North America/Canada/Newfoundland and Labrador/*

--- a/phylogenetic/defaults/color_orderings.tsv
+++ b/phylogenetic/defaults/color_orderings.tsv
@@ -222,6 +222,76 @@ region	Europe
 region	South America
 region	North America
 
+################
+
+# Canadian Provences
+division	Alberta
+division	British Columbia
+division	Manitoba
+division	New Brunswick
+division	Newfoundland and Labrador
+division	Northwest Territories
+division	Nova Scotia
+division	Nunavut
+division	Ontario
+division	Prince Edward Island
+division	Quebec
+division	Saskatchewan
+division	Yukon
+
+# USA States
+division	Alaska
+division	Alabama
+division	Arkansas
+division	Arizona
+division	California
+division	Colorado
+division	Connecticut
+division	Delaware
+division	Florida
+division	Georgia
+division	Hawaii
+division	Iowa
+division	Idaho
+division	Illinois
+division	Indiana
+division	Kansas
+division	Kentucky
+division	Louisiana
+division	Massachusetts
+division	Maryland
+division	Maine
+division	Michigan
+division	Minnesota
+division	Missouri
+division	Mississippi
+division	Montana
+division	North Carolina
+division	North Dakota
+division	Nebraska
+division	New Hampshire
+division	New Jersey
+division	New Mexico
+division	Nevada
+division	New York
+division	Ohio
+division	Oklahoma
+division	Oregon
+division	Pennsylvania
+division	Puerto Rico
+division	Rhode Island
+division	South Carolina
+division	South Dakota
+division	Tennessee
+division	Texas
+division	Utah
+division	Virginia
+division	Vermont
+division	Washington
+division	Wisconsin
+division	West Virginia
+division	Wyoming
+
 # ################
 
 MuV_genotype	A


### PR DESCRIPTION
## Description of proposed changes

In response to [slack thread](https://bedfordlab.slack.com/archives/C4SBQEHEE/p1745860169059729?thread_ts=1745859053.058139&cid=C4SBQEHEE), add alphabetical ordering to USA and Canadian divisions. 

## Related issue(s)


## Checklist

- [x] Checks pass
- [x] Test ingest and phylogenetic

* https://next.nextstrain.org/staging/mumps/trials/20250428colors/mumps/north-america


