### PR TITLE
Fix annotations

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -58,3 +58,59 @@ AY685920	MuV_genotype	N # Strain name "L-Zagreb" known genotype N
 AY685921	MuV_genotype	N # Strain name "L-Zagreb" known genotype N
 JF727651	MuV_genotype	N # Strain name "Leningrad-3" known genotype N
 JF727652	MuV_genotype	N # Strain name "Leningrad-3" known genotype N
+D00663	MuV_genotype	A # Jin et al, 2005 Genotype A
+D90231	MuV_genotype	A # Jin et al, 2005 Genotype A (End/USA45)
+D90232	MuV_genotype	A # Jin et al, 2005 Genotype A (JL/US63 vaccine)
+X72944	MuV_genotype	A # Jin et al, 2005 Genotype A (Rubini vaccine)
+AX081123	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+AX081133	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+BD293022	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+BD293023	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+DI021804	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+DI064912	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+FJ211584	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+EA500331	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+BD293024	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF345290
+DI035997	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF345290
+EA500333	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF345290
+AX081134	MuV_genotype	A # Jin et al, 2015 Genotype A identical to FN431985
+EA500331	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF338106
+EA500333	MuV_genotype	A # Jin et al, 2015 Genotype A identical to AF345290
+D90233	MuV_genotype	B # Jin et al, 2005 Genotype B
+D90236	MuV_genotype	B # Jin et al, 2005 Genotype B
+D90234	MuV_genotype	B # Jin et al, 2005 Genotype B  (Miya vaccine)
+AB003414	MuV_genotype	B # Jin et al, 2005 Genotype B (Hoshino vaccine)
+AF314558	MuV_genotype	B # Jin et al, 2015 Genotype B identical to AB000388
+X63709	MuV_genotype	C # Jin et al, 2005 Genotype C
+X63711	MuV_genotype	C # Jin et al, 2005 Genotype E(C)
+AY669145	MuV_genotype	C # Jin et al, 2015 Genotype C
+EU370206	MuV_genotype	C # WHO 2012 Genotype C SH and HN gene
+AF142766	MuV_genotype	D # Jin et al, 2005 Genotype D
+KF878076 	MuV_genotype	D # Jin et al, 2015 Genotype D
+Z77158	MuV_genotype	F # Jin et al, 2005 Genotype F
+Z77160	MuV_genotype	F # Jin et al, 2005 Genotype F
+EU780221	MuV_genotype	F # WHO 2012 Genotype F SH gene
+DQ649478	MuV_genotype	F # Jin et al, 2015 Genotype F identical to FJ556896
+FJ556896	MuV_genotype	F # Jin et al, 2015 Genotype F
+KF17091	MuV_genotype	F # Jin et al, 2015 Genotype F
+AF142764	MuV_genotype	G # Jin et al, 2005 Genotype G
+AY380075	MuV_genotype	G # Jin et al, 2005 Genotype G
+AF280799	MuV_genotype	G # WHO 2012 Genotype G SH and HN gene
+EU597478	MuV_genotype	G # WHO 2012 Genotype G SH gene
+EU370207	MuV_genotype	G # Jin et al, 2015 Genotype G
+JN012242	MuV_genotype	G # Jin et al, 2015 Genotype G identical to JX287385
+AF142771	MuV_genotype	H # Jin et al, 2005 Genotype H
+AF467767	MuV_genotype	H # Jin et al, 2015 Genotype H
+JX287388	MuV_genotype	H # Jin et al, 2015 Genotype H
+AF180374	MuV_genotype	I # Jin et al, 2005 Genotype I
+D86174	MuV_genotype	I # Jin et al, 2005 Genotype I
+AY309060	MuV_genotype	I # WHO 2012 Genotype I HN gene
+AF142770	MuV_genotype	J # Jin et al, 2005 Genotype J
+AB03417	MuV_genotype	J # Jin et al, 2005 Genotype J
+AB105475	MuV_genotype	J # WHO 2012 Genotype J SH gene
+AF365891	MuV_genotype	K # Jin et al, 2005 Genotype K
+AB105480	MuV_genotype	L # Jin et al, 2005 Genotype L
+AB105483	MuV_genotype	L # Jin et al, 2005 Genotype L
+AJ272363	MuV_genotype	N # Jin et al, 2005 becomes Genotype N
+AY493374	MuV_genotype	N # Jin et al, 2005 becomes Genotype N
+AY508995	MuV_genotype	N # WHO 2012 Genotype N SH and HN gene

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -4,3 +4,57 @@
 # If there are multiple annotations for the same id and field, then the last value is used
 # Lines starting with '#' are treated as comments
 # Any '#' after the field value are treated as comments.
+OQ990823	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+AF201473	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+FN431985	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+HQ416906	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+HQ416907	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+JQ946550	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+JQ946551	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+JQ946552	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+JQ946553	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+JQ946554	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+AF338106	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+AF345290	MuV_genotype	A # Strain name "Jeryl-Lynn" is genotype A
+FJ211586	MuV_genotype	A # Strain name "JL1; Jeryl Lynn major component" is genotype A
+GU980052	MuV_genotype	A # Strain name "Enders" is genotype A
+FJ375178	MuV_genotype	B # Urabe is genotype B based on https://pubmed.ncbi.nlm.nih.gov/25424978/
+AB000386	MuV_genotype	B # Strain name "Urabe AM-9-A" is genotype B
+AB000387	MuV_genotype	B # Strain name "Urabe AM-9-B" is genotype B
+AB000388	MuV_genotype	B # Strain name "Urabe AM-9" is genotype B
+FJ375177	MuV_genotype	B # Strain name "Urabe" is genotype B
+AB470486	MuV_genotype	B # Strain name "Hoshino vaccine" derived from "Urabe" is genotype B
+AB744048	MuV_genotype	B # Strain name "Miyahara vaccine lot3" known genotype B
+AB744049	MuV_genotype	B # Strain name "Miyahara parent" known genotype B
+NC_002200	MuV_genotype	B # Strain name "Miyahara" known genotype B
+AB040874	MuV_genotype	B # Strain name "Miyahara" known genotype B
+AB823535	MuV_genotype	B # Strain name "MuVi/Hikaru.JPN/22.97-B"
+AB827968	MuV_genotype	B # Strain name "MuVi/NK-M46.JPN/0.70[B] (Vac)"
+MK033748	MuV_genotype	C # Strain name MuVi/Ontario.CAN/09.17/5[C], was misclassified as G in datasets
+ON783699	MuV_genotype	C # Strain name MuVi/Chennai.IND/49.11/1/C
+ON783700	MuV_genotype	C # Strain name MuVi/Chennai.IND/49.11/2/C
+ON783701	MuV_genotype	C # Strain name MuVi/Chennai.IND/6.13/C
+EU884413	MuV_genotype	F # Note in the genbank entry
+KF170916	MuV_genotype	F # Note in the genbank entry
+KF170917	MuV_genotype	F # Note in the genbank entry
+KF170918	MuV_genotype	F # Note in the genbank entry
+KF170919	MuV_genotype	F # Note in the genbank entry
+JX287385	MuV_genotype	G # Note in the genbank entry
+JX287387	MuV_genotype	G # Note in the genbank entry
+JX287389	MuV_genotype	G # Note in the genbank entry
+JX287390	MuV_genotype	G # Note in the genbank entry
+JX287391	MuV_genotype	G # Note in the genbank entry
+KF481689	MuV_genotype	G # Strain name "MuVi/Zagreb.HRV/28.12(G)"
+JN635498	MuV_genotype	G # Strain name "MuVi/Split.CRO/05.11(G)"
+AB600843	MuV_genotype	H # Based on https://pmc.ncbi.nlm.nih.gov/articles/PMC3122658/
+AB576764	MuV_genotype	H # Based on publication name in genbank entry
+AB600942	MuV_genotype	H # Based on publication name in genbank entry
+AB600942	MuV_genotype	H # Based on publication name in genbank entry
+AY681495	MuV_genotype	H # Strain name "MuVi/Novosibirsk.RUS/10.03-H"
+MG986430	MuV_genotype	K # Note in the genbank entry
+MG986430	MuV_genotype	K # Note in the genbank entry
+JX287386	MuV_genotype	K # Note in the genbank entry
+AY685920	MuV_genotype	N # Strain name "L-Zagreb" known genotype N
+AY685921	MuV_genotype	N # Strain name "L-Zagreb" known genotype N
+JF727651	MuV_genotype	N # Strain name "Leningrad-3" known genotype N
+JF727652	MuV_genotype	N # Strain name "Leningrad-3" known genotype N

--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -47,7 +47,7 @@ JX287391	MuV_genotype	G # Note in the genbank entry
 KF481689	MuV_genotype	G # Strain name "MuVi/Zagreb.HRV/28.12(G)"
 JN635498	MuV_genotype	G # Strain name "MuVi/Split.CRO/05.11(G)"
 AB600843	MuV_genotype	H # Based on https://pmc.ncbi.nlm.nih.gov/articles/PMC3122658/
-AB576764	MuV_genotype	H # Based on publication name in genbank entry
+AB576764	MuV_genotype	B # Jin et al, 2015 Genotype B
 AB600942	MuV_genotype	H # Based on publication name in genbank entry
 AB600942	MuV_genotype	H # Based on publication name in genbank entry
 AY681495	MuV_genotype	H # Strain name "MuVi/Novosibirsk.RUS/10.03-H"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -21,8 +21,8 @@ ancestral:
   inference: "joint"
 
 traits:
-  north-america: country division
-  global: region
+  north-america: country division MuV_genotype
+  global: region MuV_genotype
   sampling_bias_correction: 3
 
 colors:

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -100,7 +100,7 @@ rule traits:
             --metadata {input.metadata:q} \
             --metadata-id-columns {params.strain_id:q} \
             --output {output.node_data:q} \
-            --columns {params.columns:q} \
+            --columns {params.columns} \
             --confidence \
             --sampling-bias-correction {params.sampling_bias_correction:q} | tee {log:q}
         """


### PR DESCRIPTION
## Description of proposed changes

This update manually fills in a few missing or misannotated MuV_genotype entries for Mumps records.

1. Examine the global or North America whole genome sequence trees. For grey nodes (those missing `MuV_genotype`), retrieve the associated GenBank records and search for a "genotype:" note. Manually inspect these entries in the table before including them in the manual annotations.

```bash
python batch-fetch-genbank-records.py --ids Mumps.ids --output-genbank Mumps.gb
grep -e "^LOCUS" -e "genotype" -e "/strain" Mumps.gb > rough_table.txt
```

2. While reviewing the literature for representative sequences in the Mumps Nextclade dataset, fill in any missing `MuV_genotype` values.

3. Enable trait inference of `MuV_genotype` in the phylogenetic workflow.

4. Fix a bug where 'country division' was incorrectly quoted instead of quoting 'country' and 'division' separately.

## Related issue(s)

* While part of working toward a Nextclade dataset: https://github.com/nextstrain/mumps/issues/17 , fixing various annotations.

## Checklist

- [ ] Checks pass
- [x] [GH Action ingest](https://github.com/nextstrain/mumps/actions/runs/14985123789) works

