### PR TITLE
phylogenetic: include the edited variants of the P gene in the reference

### DIFF
--- a/phylogenetic/defaults/reference.gb
+++ b/phylogenetic/defaults/reference.gb
@@ -82,7 +82,7 @@ FEATURES             Location/Qualifiers
                      RDYGPP"
      gene            1916..2426
                      /gene="I"
-     CDS             join(1916..2380,2377..2426)
+     CDS             join(1916..2380,2376..2426)
                      /gene="I"
                      /exception="RNA editing"
                      /note="four non-templated G residues inserted during


### PR DESCRIPTION
## Description of proposed changes

Similar to the [fix in the Nextclade workflow](https://github.com/nextstrain/mumps/blame/41654ec8e601f4669146d4c3ac1834ae7f74c12f/nextclade/defaults/genome/reference.gb#L54)

1. Align the nextclade genome reference and the phylogenetic genome reference
2. Compare P and I CDS and gene annotations
3. Glance at the annotated translations and the automatic translations

Basically changing from original:

<img width="1187" height="40" alt="Screenshot 2025-08-18 at 11 32 08 AM" src="https://github.com/user-attachments/assets/c931e52f-6fbf-4076-94ac-45ad9a415b1f" />

to: 

<img width="1161" height="46" alt="Screenshot 2025-08-18 at 11 37 04 AM" src="https://github.com/user-attachments/assets/b851caa8-316b-424d-97f3-dc79e80e08a9" />

## Related issue(s)

## Checklist

- [ ] Checks pass
- [ ] Update changelog

