### PR TITLE
Added option for alternative divergence units for augur refine (--divergence-units) to be specified via config.yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ We use this CHANGELOG to document breaking changes, new features, bug fixes,
 and config value changes that may affect both the usage of the workflows and
 the outputs of the workflows.
 
+## 2026
+* 13 July 2026: [Divergence units](https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/refine.html) can now be configured using `refine.divergence_units`.
+
 ## 2025
 
 * 13 October 2025: phylogenetic and nextclade - Update to color handling ([#48][])

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -22,6 +22,7 @@ filter:
 refine:
   north-america: "--clock-filter-iqd 4"
   global: ""
+  divergence_units: "mutations-per-site"
 
 ancestral:
   inference: "joint"

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -62,6 +62,7 @@ rule refine:
         date_inference = "marginal",
         clock_filter_iqd = lambda wildcard: config['refine'][wildcard.build],
         strain_id = config.get("strain_id_field", "strain"),
+        divergence_units=config["refine"]["divergence_units"],
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -76,5 +77,6 @@ rule refine:
             --timetree \
             --coalescent {params.coalescent:q} \
             --date-confidence \
-            --date-inference {params.date_inference:q} {params.clock_filter_iqd}
+            --date-inference {params.date_inference:q} {params.clock_filter_iqd} \
+            --divergence-units {params.divergence_units:q}
         """


### PR DESCRIPTION
keep default as mutations-per-site

## Description of proposed changes

This keeps the default divergence units for augur refine as mutations-per-site but routes this option to the config and makes it explicit. This should allow for the divergence/x-axis units to be visualized in terms of absolute number of mutations easily in a custom config.

Tested with standard run (global & NA build)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
