### PR TITLE
Build-specific refine options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ We use this CHANGELOG to document breaking changes, new features, bug fixes,
 and config value changes that may affect both the usage of the workflows and
 the outputs of the workflows.
 
+## 2026
+
+* 14 July 2026: The refine option for clock filtering has moved from `refine.<build>: "--clock-filter-iqd <N>"` to `refine.<build>.clock_filter_iqd: <N>`. **This is a breaking change**.
+* 14 July 2026: The following refine options can be configured using `refine.<build>.<option>`: `coalescent`, `date_inference`, `timetree`, `date_confidence`, `clock_filter_iqd`.
+
 ## 2025
 
 * 13 October 2025: phylogenetic and nextclade - Update to color handling ([#48][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the outputs of the workflows.
 ## 2026
 
 * 14 July 2026: The refine option for clock filtering has moved from `refine.<build>: "--clock-filter-iqd <N>"` to `refine.<build>.clock_filter_iqd: <N>`. **This is a breaking change**.
-* 14 July 2026: The following refine options can be configured using `refine.<build>.<option>`: `coalescent`, `date_inference`, `timetree`, `date_confidence`, `clock_filter_iqd`.
+* 14 July 2026: The following refine options can be configured using `refine.<build>.<option>`: `coalescent`, `date_inference`, `timetree`, `date_confidence`, `clock_filter_iqd`, `divergence_units`.
 
 ## 2025
 

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -20,8 +20,18 @@ filter:
     global: --subsample-max-sequences 4000 --min-date 1950
 
 refine:
-  north-america: "--clock-filter-iqd 4"
-  global: ""
+  north-america:
+    coalescent: "opt"
+    date_inference: "marginal"
+    timetree: true
+    date_confidence: true
+    clock_filter_iqd: 4
+  global:
+    coalescent: "opt"
+    date_inference: "marginal"
+    timetree: true
+    date_confidence: true
+    clock_filter_iqd: null
 
 ancestral:
   inference: "joint"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -26,12 +26,14 @@ refine:
     timetree: true
     date_confidence: true
     clock_filter_iqd: 4
+    divergence_units: "mutations-per-site"
   global:
     coalescent: "opt"
     date_inference: "marginal"
     timetree: true
     date_confidence: true
     clock_filter_iqd: null
+    divergence_units: "mutations-per-site"
 
 ancestral:
   inference: "joint"

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -6,4 +6,23 @@ OUTPUTS:
     results/run_config.yaml
 """
 
+def conditional(option, argument):
+    """Used for config-defined arguments whose presence necessitates a command-line option
+    (e.g. --foo) prepended and whose absence should result in no option/arguments in the CLI command.
+    *argument* can be falsey, in which case an empty string is returned (i.e. "don't pass anything
+    to the CLI"), or a *list* or *string* or *number* in which case a flat list of options/args is returned,
+    or *True* in which case a list of a single element (the option) is returned.
+    Any other argument type is a WorkflowError
+    """
+    if not argument:
+        return ""
+    if argument is True: # must come before `isinstance(argument, int)` as bool is a subclass of int
+        return [option]
+    if isinstance(argument, list):
+        return [option, *argument]
+    if isinstance(argument, int) or isinstance(argument, float) or isinstance(argument, str):
+        return [option, argument]
+    raise WorkflowError(f"Workflow function conditional() received an argument value of unexpected type: {type(argument).__name__}")
+
+
 write_config("results/run_config.yaml")

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -9,12 +9,12 @@ OUTPUTS:
 def conditional(option, argument):
     """Used for config-defined arguments whose presence necessitates a command-line option
     (e.g. --foo) prepended and whose absence should result in no option/arguments in the CLI command.
-    *argument* can be falsey, in which case an empty string is returned (i.e. "don't pass anything
+    *argument* can be None, in which case an empty string is returned (i.e. "don't pass anything
     to the CLI"), or a *list* or *string* or *number* in which case a flat list of options/args is returned,
     or *True* in which case a list of a single element (the option) is returned.
     Any other argument type is a WorkflowError
     """
-    if not argument:
+    if argument is None:
         return ""
     if argument is True: # must come before `isinstance(argument, int)` as bool is a subclass of int
         return [option]

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -63,6 +63,7 @@ rule refine:
         timetree = lambda w: conditional("--timetree", config["refine"][w.build].get("timetree")),
         date_confidence = lambda w: conditional("--date-confidence", config["refine"][w.build].get("date_confidence")),
         clock_filter_iqd = lambda w: conditional("--clock-filter-iqd", config["refine"][w.build].get("clock_filter_iqd")),
+        divergence_units = lambda w: conditional("--divergence-units", config["refine"][w.build].get("divergence_units")),
         strain_id = config.get("strain_id_field", "strain"),
     shell:
         r"""
@@ -78,6 +79,7 @@ rule refine:
             {params.date_confidence} \
             {params.date_inference} \
             {params.clock_filter_iqd} \
+            {params.divergence_units} \
             --output-tree {output.tree:q} \
             --output-node-data {output.node_data:q}
         """

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -58,9 +58,11 @@ rule refine:
     benchmark:
         "benchmarks/{build}/refine.txt",
     params:
-        coalescent = "opt",
-        date_inference = "marginal",
-        clock_filter_iqd = lambda wildcard: config['refine'][wildcard.build],
+        coalescent = lambda w: conditional("--coalescent", config["refine"][w.build].get("coalescent")),
+        date_inference = lambda w: conditional("--date-inference", config["refine"][w.build].get("date_inference")),
+        timetree = lambda w: conditional("--timetree", config["refine"][w.build].get("timetree")),
+        date_confidence = lambda w: conditional("--date-confidence", config["refine"][w.build].get("date_confidence")),
+        clock_filter_iqd = lambda w: conditional("--clock-filter-iqd", config["refine"][w.build].get("clock_filter_iqd")),
         strain_id = config.get("strain_id_field", "strain"),
     shell:
         r"""
@@ -71,10 +73,11 @@ rule refine:
             --alignment {input.alignment:q} \
             --metadata {input.metadata:q} \
             --metadata-id-columns {params.strain_id:q} \
+            {params.timetree} \
+            {params.coalescent} \
+            {params.date_confidence} \
+            {params.date_inference} \
+            {params.clock_filter_iqd} \
             --output-tree {output.tree:q} \
-            --output-node-data {output.node_data:q} \
-            --timetree \
-            --coalescent {params.coalescent:q} \
-            --date-confidence \
-            --date-inference {params.date_inference:q} {params.clock_filter_iqd}
+            --output-node-data {output.node_data:q}
         """


### PR DESCRIPTION
## Description of proposed changes

Previously, only the clock filter was configurable per build through `refine.<build>: "--clock-filter-iqd <N>"`. This PR makes that `refine.<build>.clock_filter_iqd: <N>`, and makes other options available using the same syntax.

## Related issue(s)

Alternative to, closes #58

[Slack context](https://bedfordlab.slack.com/archives/C01G4B4UY31/p1784049815909289?thread_ts=1783988739.650479&cid=C01G4B4UY31)

## Checklist

- [x] Checks pass
- [x] Update changelog
