### PR TITLE
Use CLI argument strings in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ the outputs of the workflows.
 
 ## 2026
 
+* 20 July 2026: Command-line parameters for `filter`, `refine`, `ancestral`, `traits`, and `tip_frequencies` are now defined as a single argument string under `<rule>.<build>` in config. This reverts the change from 14 July 2026 and provides a consistent and flexible pattern for passing **non-file** arguments to Augur **This is a breaking change**.
 * 14 July 2026: The refine option for clock filtering has moved from `refine.<build>: "--clock-filter-iqd <N>"` to `refine.<build>.clock_filter_iqd: <N>`. **This is a breaking change**.
 * 14 July 2026: The following refine options can be configured using `refine.<build>.<option>`: `coalescent`, `date_inference`, `timetree`, `date_confidence`, `clock_filter_iqd`, `divergence_units`.
 

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -10,39 +10,74 @@ inputs:
 strain_id_field: "accession"
 reference: "reference.gb"
 
+
+####### Rule-specific parameters #######
+#
+# Most parameters are configured in argument strings given to Augur's command
+# line interface. See each command's reference page for detailed usage docs.
+#
+#   <rule>:
+#     <build>: <argument string>
+#
+# Strings can be formatted across multiple lines in YAML for readability. The '>'
+# block style indicator replaces newlines with spaces, and the '-' block chomping
+# indicator strips trailing newlines.
+#
+# File references have dedicated YAML config parameters. While they are
+# mentioned on Augur command reference pages, they should *not* be configured in
+# argument strings, but instead using their dedicated YAML config parameters.
+# They can be customized per build by referencing '{build}' in the path.
+
+# https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/filter.html
 filter:
-  min_length: 8000
-  group_by: country year month MuV_genotype division
   exclude: "{build}/exclude.txt"
   include: "{build}/include.txt"
-  specific:
-    north-america: --subsample-max-sequences 4000 --min-date 2006 --query "region=='North America' & (MuV_genotype=='G')"
-    global: --subsample-max-sequences 4000 --min-date 1950
+  north-america: >-
+    --min-length 8000
+    --group-by country year month MuV_genotype division
+    --subsample-max-sequences 4000
+    --min-date 2006
+    --query "region=='North America' & (MuV_genotype=='G')"
+  global: >-
+    --min-length 8000
+    --group-by country year month MuV_genotype division
+    --subsample-max-sequences 4000
+    --min-date 1950
 
+# https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/refine.html
 refine:
-  north-america:
-    coalescent: "opt"
-    date_inference: "marginal"
-    timetree: true
-    date_confidence: true
-    clock_filter_iqd: 4
-    divergence_units: "mutations-per-site"
-  global:
-    coalescent: "opt"
-    date_inference: "marginal"
-    timetree: true
-    date_confidence: true
-    clock_filter_iqd: null
-    divergence_units: "mutations-per-site"
+  north-america: >-
+    --coalescent "opt"
+    --date-inference "marginal"
+    --timetree
+    --date-confidence
+    --clock-filter-iqd 4
+    --divergence-units "mutations-per-site"
+  global: >-
+    --coalescent "opt"
+    --date-inference "marginal"
+    --timetree
+    --date-confidence
+    --divergence-units "mutations-per-site"
 
+# https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/ancestral.html
 ancestral:
-  inference: "joint"
   root_sequence: "reference.gb"
+  north-america: >-
+    --inference "joint"
+  global: >-
+    --inference "joint"
 
+# https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/traits.html
 traits:
-  north-america: country division MuV_genotype MuV_genotype_nextclade_sh MuV_genotype_nextclade_genome
-  global: region MuV_genotype MuV_genotype_nextclade_sh MuV_genotype_nextclade_genome
-  sampling_bias_correction: 3
+  north-america: >-
+    --columns country division MuV_genotype MuV_genotype_nextclade_sh MuV_genotype_nextclade_genome
+    --sampling-bias-correction 3
+    --confidence
+  global: >-
+    --columns region MuV_genotype MuV_genotype_nextclade_sh MuV_genotype_nextclade_genome
+    --sampling-bias-correction 3
+    --confidence
 
 colors:
   color_schemes: "color_schemes.tsv"
@@ -53,10 +88,19 @@ export:
   auspice_config: "{build}/auspice_config.json"
   description: "description.md"
 
+# https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/frequencies.html
 tip_frequencies:
-  # 2006 since there is an increase in mumps samples at that time
-  min_date: "2006-01-01"
-  max_date: "12M"
-  # Quarterly narrow_bandwidth or every 3 months (3 /12.0 = 0.25)
-  narrow_bandwidth: 0.25
-  proportion_wide: 0.0
+  # --min-date: 2006 since there is an increase in mumps samples at that time
+  # --narrow-bandwidth: Quarterly or every 3 months (3 /12.0 = 0.25)
+  north-america: >-
+    --min-date "2006-01-01"
+    --max-date "12M"
+    --narrow-bandwidth 0.25
+    --proportion-wide 0.0
+    --method kde
+  global: >-
+    --min-date "2006-01-01"
+    --max-date "12M"
+    --narrow-bandwidth 0.25
+    --proportion-wide 0.0
+    --method kde

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -44,7 +44,7 @@ rule ancestral:
     benchmark:
         "benchmarks/{build}/ancestral.txt",
     params:
-        inference = config["ancestral"]["inference"],
+        args = lambda w: config["ancestral"][w.build],
         root_sequence=lambda w: (
             ("--root-sequence " + resolve_config_path(config["ancestral"]["root_sequence"])(w))
             if config["ancestral"].get("root_sequence")
@@ -59,7 +59,7 @@ rule ancestral:
             --alignment {input.alignment:q} \
             --output-node-data {output.node_data:q} \
             {params.root_sequence} \
-            --inference {params.inference:q}
+            {params.args}
         """
 
 rule translate:
@@ -87,8 +87,7 @@ rule translate:
 
 rule traits:
     """
-    Inferring ancestral traits for {params.columns!s}
-      - increase uncertainty of reconstruction by {params.sampling_bias_correction} to partially account for sampling bias
+    Inferring ancestral traits
     """
     input:
         tree = "results/{build}/tree.nwk",
@@ -100,8 +99,7 @@ rule traits:
     benchmark:
         "benchmarks/{build}/traits.txt",
     params:
-        columns = lambda wildcard: config['traits'][wildcard.build],
-        sampling_bias_correction = config["traits"]["sampling_bias_correction"],
+        args = lambda w: config['traits'][w.build],
         strain_id = config.get("strain_id_field", "strain"),
     shell:
         r"""
@@ -112,7 +110,5 @@ rule traits:
             --metadata {input.metadata:q} \
             --metadata-id-columns {params.strain_id:q} \
             --output {output.node_data:q} \
-            --columns {params.columns} \
-            --confidence \
-            --sampling-bias-correction {params.sampling_bias_correction:q}
+            {params.args}
         """

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -41,10 +41,6 @@ rule tree:
 rule refine:
     """
     Refining tree
-      - estimate timetree
-      - use {params.coalescent} coalescent timescale
-      - estimate {params.date_inference} node dates
-      - filter tips more than {params.clock_filter_iqd} IQDs from clock expectation
     """
     input:
         tree = "results/{build}/tree_raw.nwk",
@@ -58,12 +54,7 @@ rule refine:
     benchmark:
         "benchmarks/{build}/refine.txt",
     params:
-        coalescent = lambda w: conditional("--coalescent", config["refine"][w.build].get("coalescent")),
-        date_inference = lambda w: conditional("--date-inference", config["refine"][w.build].get("date_inference")),
-        timetree = lambda w: conditional("--timetree", config["refine"][w.build].get("timetree")),
-        date_confidence = lambda w: conditional("--date-confidence", config["refine"][w.build].get("date_confidence")),
-        clock_filter_iqd = lambda w: conditional("--clock-filter-iqd", config["refine"][w.build].get("clock_filter_iqd")),
-        divergence_units = lambda w: conditional("--divergence-units", config["refine"][w.build].get("divergence_units")),
+        args = lambda w: config["refine"][w.build],
         strain_id = config.get("strain_id_field", "strain"),
     shell:
         r"""
@@ -74,12 +65,7 @@ rule refine:
             --alignment {input.alignment:q} \
             --metadata {input.metadata:q} \
             --metadata-id-columns {params.strain_id:q} \
-            {params.timetree} \
-            {params.coalescent} \
-            {params.date_confidence} \
-            {params.date_inference} \
-            {params.clock_filter_iqd} \
-            {params.divergence_units} \
             --output-tree {output.tree:q} \
-            --output-node-data {output.node_data:q}
+            --output-node-data {output.node_data:q} \
+            {params.args}
         """

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -99,23 +99,16 @@ rule tip_frequencies:
     log:
         "logs/{build}/tip_frequencies.txt"
     params:
+        args = lambda w: config["tip_frequencies"][w.build],
         strain_id = config["strain_id_field"],
-        min_date = config["tip_frequencies"]["min_date"],
-        max_date = config["tip_frequencies"]["max_date"],
-        narrow_bandwidth = config["tip_frequencies"]["narrow_bandwidth"],
-        proportion_wide = config["tip_frequencies"]["proportion_wide"]
     shell:
         r"""
         exec &> >(tee {log:q})
 
         augur frequencies \
-            --method kde \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
-            --min-date {params.min_date} \
-            --max-date {params.max_date} \
-            --narrow-bandwidth {params.narrow_bandwidth} \
-            --proportion-wide {params.proportion_wide} \
-            --output {output.tip_freq}
+            --output {output.tip_freq} \
+            {params.args}
         """

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -24,12 +24,7 @@ See Augur's usage docs for these commands for more details.
 
 rule filter:
     """
-    Filtering to
-      - various criteria based on the auspice JSON target
-      - from {params.min_date} onwards
-      - excluding strains in {input.exclude}
-      - including strains in {input.include}
-      - minimum genome length of {params.min_length}
+    Filtering sequences
     """
     input:
         sequences = "results/sequences.fasta",
@@ -44,9 +39,7 @@ rule filter:
     benchmark:
         "benchmarks/{build}/filtered.txt",
     params:
-        min_length = config['filter']['min_length'],
-        group_by = config['filter']['group_by'],
-        filter_params = lambda wildcard: config['filter']['specific'][wildcard.build],
+        args = lambda w: config['filter'][w.build],
         strain_id = config.get("strain_id_field", "strain"),
     shell:
         r"""
@@ -60,9 +53,7 @@ rule filter:
             --include {input.include:q} \
             --output-sequences {output.sequences:q} \
             --output-metadata {output.metadata:q} \
-            --min-length {params.min_length:q} \
-            --group-by {params.group_by} \
-            {params.filter_params}
+            {params.args}
         """
 
 rule align:


### PR DESCRIPTION
## Description of proposed changes

Command-line parameters for `filter`, `refine`, `ancestral`, `traits`, and `tip_frequencies` are now defined as a single argument string under `<rule>.<build>` in config. This reverts #59 and provides a consistent and flexible pattern for passing non-file arguments to Augur.

The pattern is described in detail here: https://gist.github.com/victorlin/bcac1061cbbd23d67cfa30359a621de1

Draft of necessary changes on NW-PaGe fork: https://github.com/nextstrain/mumps/commit/263ac685fae7365b20b26e6dac857c32f25c1fa9

## Related issue(s)

[Slack thread](https://bedfordlab.slack.com/archives/C01G4B4UY31/p1784066384386949)

## Checklist

- [x] Checks pass
- [x] Update changelog
